### PR TITLE
corregí error en boton onchange

### DIFF
--- a/src/views/SignUp/SignUpForm.js
+++ b/src/views/SignUp/SignUpForm.js
@@ -127,7 +127,6 @@ const SignUpForm = () => {
           </div>
 
           <button
-            onSubmit
             type='submit'
             className='block w-full bg-blue-700 mt-5 py-2 rounded-2xl hover:bg-blue-400 hover:-translate-y-1 transition-all duration-500 text-white font-semibold mb-2'
           >


### PR DESCRIPTION
La consola explotaba porque se le había asignado onChange al botón del formulario 